### PR TITLE
Added a test for encoding usage in non-ascii files

### DIFF
--- a/Kajabity Tools.Test/Kajabity Tools.Test.csproj
+++ b/Kajabity Tools.Test/Kajabity Tools.Test.csproj
@@ -112,6 +112,12 @@
     <None Include="Test Data\Csv\unix-line-ends.csv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Test Data\Java\non-ascii-symbols-native2ascii.properties">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Test Data\Java\non-ascii-symbols-utf8.properties">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Test Data\Java\comments.properties">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Kajabity Tools.Test/Test Data/Java/non-ascii-symbols-native2ascii.properties
+++ b/Kajabity Tools.Test/Test Data/Java/non-ascii-symbols-native2ascii.properties
@@ -1,0 +1,3 @@
+Greeting = \u041f\u0440\u0438\u0432\u0435\u0442
+MixedValue = \u0422\u0432\u044a\u0440\u0434 \u0414\u0438\u0441\u043a Western Digital -  Black Series
+AsciiText = This is valid ASCII text

--- a/Kajabity Tools.Test/Test Data/Java/non-ascii-symbols-utf8.properties
+++ b/Kajabity Tools.Test/Test Data/Java/non-ascii-symbols-utf8.properties
@@ -1,0 +1,3 @@
+Greeting = Привет
+MixedValue = Твърд Диск Western Digital -  Black Series
+AsciiText = This is valid ASCII text


### PR DESCRIPTION
Added a test case that shows how encoding makes a difference when reading property files stored using UTF8 encoding, as compared to ones stored via ISO-8859-1. The test confirms that non-escaped UTF8 files are identical to the same file processed via `native2ascii` tool _only_ if properly loaded with UTF8 encoding.
